### PR TITLE
feat: add custom base path support for OpenCode terminal sessions

### DIFF
--- a/src/main/kotlin/ai/opencode/ide/jetbrains/OpenCodeService.kt
+++ b/src/main/kotlin/ai/opencode/ide/jetbrains/OpenCodeService.kt
@@ -511,12 +511,14 @@ class OpenCodeService(private val project: Project) : Disposable {
         AppExecutorUtil.getAppExecutorService().submit {
             val suggested = PortFinder.findAvailablePort()
             ApplicationManager.getApplication().invokeLater {
-                OpenCodeConnectDialog.show(project, suggested)?.let { processConnectionChoice(it.hostname, it.port, it.password, it.useWebInterface) }
+                OpenCodeConnectDialog.show(project, suggested)?.let { 
+                    processConnectionChoice(it.hostname, it.port, it.password, it.useWebInterface, it.customBasePath) 
+                }
             }
         }
     }
 
-    private fun processConnectionChoice(h: String, p: Int, pwd: String?, web: Boolean) {
+    private fun processConnectionChoice(h: String, p: Int, pwd: String?, web: Boolean, customBasePath: String? = null) {
         val safeH = h.trim().ifBlank { "127.0.0.1" }
         val local = safeH in listOf("0.0.0.0", "127.0.0.1", "localhost")
         
@@ -530,7 +532,7 @@ class OpenCodeService(private val project: Project) : Disposable {
                     lastMode = if (!local) ConnectionMode.REMOTE else if (web) ConnectionMode.WEB else ConnectionMode.TERMINAL
                     // For remote (!local), strict headless unless web mode.
                     // For local, if running, we also just connect (headless or web), we do NOT spawn a new terminal.
-                    connectToExistingServer(safeH, p, a, web, web)
+                    connectToExistingServer(safeH, p, a, web, web, customBasePath)
                 } else if (occupied) {
                     val choice = Messages.showYesNoDialog(
                         project,
@@ -542,7 +544,7 @@ class OpenCodeService(private val project: Project) : Disposable {
                     )
                     if (choice == Messages.YES) {
                         lastMode = if (!local) ConnectionMode.REMOTE else if (web) ConnectionMode.WEB else ConnectionMode.TERMINAL
-                        connectToExistingServer(safeH, p, a, web, web)
+                        connectToExistingServer(safeH, p, a, web, web, customBasePath)
                     } else {
                         showConnectionDialog()
                     }
@@ -554,16 +556,16 @@ class OpenCodeService(private val project: Project) : Disposable {
                          showConnectionDialog()
                     } else {
                         lastMode = if (web) ConnectionMode.WEB else ConnectionMode.TERMINAL
-                        if (web) createWebTerminal(safeH, p, a.password) else createLocalTerminal(safeH, p, a.password)
+                        if (web) createWebTerminal(safeH, p, a.password, customBasePath) else createLocalTerminal(safeH, p, a.password, customBasePath)
                     }
                 }
             }
         }
     }
 
-    private fun connectToExistingServer(h: String, p: Int, a: ProcessAuthDetector.ServerAuth, ui: Boolean, web: Boolean) {
+    private fun connectToExistingServer(h: String, p: Int, a: ProcessAuthDetector.ServerAuth, ui: Boolean, web: Boolean, customBasePath: String? = null) {
         hostname = h; port = p; username = a.username; password = a.password
-        if (ui) { if (web) createWebUI(h, p) else createTerminalUIInternal(h, p, a.password, false) }
+        if (ui) { if (web) createWebUI(h, p) else createTerminalUIInternal(h, p, a.password, false, null, customBasePath) }
         else { ApplicationManager.getApplication().invokeLater { Messages.showInfoMessage(project, "Connected to $h:$p", "OpenCode") } }
         initializeApiClient(h, p); startConnectionManager()
     }
@@ -572,7 +574,7 @@ class OpenCodeService(private val project: Project) : Disposable {
         webVirtualFile = WebModeSupport.openWebTab(project, h, p, password) { if (webVirtualFile == null) terminateProcess() }
     }
 
-    private fun createWebTerminal(h: String, p: Int, pwd: String?) {
+    private fun createWebTerminal(h: String, p: Int, pwd: String?, customBasePath: String? = null) {
         AppExecutorUtil.getAppExecutorService().submit {
             val bin = detectOpenCodeBinary()
             if (bin == null) {
@@ -581,7 +583,7 @@ class OpenCodeService(private val project: Project) : Disposable {
             }
             ApplicationManager.getApplication().invokeLater {
                 hostname = h; port = p; lastMode = ConnectionMode.WEB
-                createTerminalUIInternal(h, p, pwd, true, bin)
+                createTerminalUIInternal(h, p, pwd, true, bin, customBasePath)
             }
             // Increase timeout to 30s for all platforms
             if (!PortFinder.waitForPort(p, h, timeoutMs = 30000, requireHealth = true)) {
@@ -595,11 +597,11 @@ class OpenCodeService(private val project: Project) : Disposable {
         }
     }
 
-    private fun createLocalTerminal(h: String, p: Int, pwd: String?) {
+    private fun createLocalTerminal(h: String, p: Int, pwd: String?, customBasePath: String? = null) {
         val safeH = h.trim().ifBlank { "127.0.0.1" }
         if (safeH !in listOf("0.0.0.0", "127.0.0.1", "localhost")) {
             // Guard: Never attempt to spawn local terminal for remote host
-            connectToExistingServer(safeH, p, ProcessAuthDetector.ServerAuth("opencode", pwd), false, false)
+            connectToExistingServer(safeH, p, ProcessAuthDetector.ServerAuth("opencode", pwd), false, false, customBasePath)
             return
         }
         AppExecutorUtil.getAppExecutorService().submit {
@@ -610,7 +612,7 @@ class OpenCodeService(private val project: Project) : Disposable {
             }
             ApplicationManager.getApplication().invokeLater {
                 hostname = h; port = p; lastMode = ConnectionMode.TERMINAL
-                createTerminalUIInternal(h, p, pwd, true, bin)
+                createTerminalUIInternal(h, p, pwd, true, bin, customBasePath)
             }
             // Increase timeout to 30s for all platforms (Windows startup can be slow)
             if (!PortFinder.waitForPort(p, h, timeoutMs = 30000)) {
@@ -622,9 +624,10 @@ class OpenCodeService(private val project: Project) : Disposable {
         }
     }
 
-    private fun createTerminalUIInternal(h: String, p: Int, pwd: String?, cont: Boolean = true, command: String? = null) {
+    private fun createTerminalUIInternal(h: String, p: Int, pwd: String?, cont: Boolean = true, command: String? = null, customBasePath: String? = null) {
         val t = "$OPEN_CODE_TAB_PREFIX($p)"
-        val w = TerminalView.getInstance(project).createLocalShellWidget(project.basePath, t)
+        val wd = customBasePath ?: project.basePath
+        val w = TerminalView.getInstance(project).createLocalShellWidget(wd, t)
         OpenCodeTerminalLinkFilter.install(project, w)
         val f = OpenCodeTerminalVirtualFile(t)
         terminalVirtualFile = f; OpenCodeTerminalFileEditorProvider.registerWidget(f, w)
@@ -632,7 +635,7 @@ class OpenCodeService(private val project: Project) : Disposable {
             terminalEditor = FileEditorManager.getInstance(project).openFile(f, true).firstOrNull { it is OpenCodeTerminalFileEditor } as? OpenCodeTerminalFileEditor
             terminalEditor?.let { 
                 val cmd = command ?: getOpenCodeBinary()
-                w.executeCommand(buildOpenCodeCommand(cmd, h, p, pwd, cont)); pinTerminalTab(f) 
+                w.executeCommand(buildOpenCodeCommand(cmd, h, p, pwd, cont)); pinTerminalTab(f)
             }
         }
     }

--- a/src/main/kotlin/ai/opencode/ide/jetbrains/ui/OpenCodeConnectDialog.kt
+++ b/src/main/kotlin/ai/opencode/ide/jetbrains/ui/OpenCodeConnectDialog.kt
@@ -28,17 +28,21 @@ class OpenCodeConnectDialog(
         val hostname: String,
         val port: Int,
         val password: String?,
-        val useWebInterface: Boolean
+        val useWebInterface: Boolean,
+        val customBasePath: String? = null
     )
 
     private val addressField = JBTextField("127.0.0.1:$defaultPort")
     private val passwordField = JBPasswordField()
+    private val basePathField = JBTextField()
     
     var hostname: String = "127.0.0.1"
         private set
     var port: Int = defaultPort
         private set
     var password: String? = null
+        private set
+    var customBasePath: String? = null
         private set
     var useWebInterface: Boolean = false
         private set
@@ -52,11 +56,12 @@ class OpenCodeConnectDialog(
 
     override fun createCenterPanel(): JComponent {
         val panel = JPanel(BorderLayout(0, JBUI.scale(8)))
-        panel.preferredSize = Dimension(JBUI.scale(300), JBUI.scale(140))
+        panel.preferredSize = Dimension(JBUI.scale(350), JBUI.scale(180))
 
-        val formPanel = JPanel(GridLayout(4, 1, 0, JBUI.scale(4)))
+        val formPanel = JPanel(GridLayout(6, 1, 0, JBUI.scale(4)))
         val addressLabel = JBLabel("Server address:")
         val passwordLabel = JBLabel("Server password (optional):")
+        val basePathLabel = JBLabel("Custom base path (optional):")
 
         // Load saved values
         val props = PropertiesComponent.getInstance()
@@ -74,14 +79,20 @@ class OpenCodeConnectDialog(
             // Ignore if password retrieval fails
         }
 
+        // Load saved custom base path
+        basePathField.text = props.getValue(PROP_CUSTOM_BASE_PATH, "")
+
         addressField.toolTipText = "Format: hostname:port (e.g., 127.0.0.1:4096)"
         passwordField.toolTipText = "OPENCODE_SERVER_PASSWORD"
         passwordField.emptyText.text = "For remote OpenCode servers"
+        basePathField.toolTipText = "Override project base path for opencode.exe working directory"
 
         formPanel.add(addressLabel)
         formPanel.add(addressField)
         formPanel.add(passwordLabel)
         formPanel.add(passwordField)
+        formPanel.add(basePathLabel)
+        formPanel.add(basePathField)
 
         panel.add(formPanel, BorderLayout.CENTER)
 
@@ -126,6 +137,9 @@ class OpenCodeConnectDialog(
         val passwordValue = passwordField.password.concatToString().trim()
         password = passwordValue.ifBlank { null }
         
+        val basePathValue = basePathField.text.trim()
+        customBasePath = basePathValue.ifBlank { null }
+
         useWebInterface = false
 
         // Save values for next time
@@ -145,12 +159,20 @@ class OpenCodeConnectDialog(
             // Ignore if password save fails
         }
 
+        // Save custom base path
+        if (!customBasePath.isNullOrBlank()) {
+            props.setValue(PROP_CUSTOM_BASE_PATH, customBasePath!!)
+        } else {
+            props.unsetValue(PROP_CUSTOM_BASE_PATH)
+        }
+
         super.doOKAction()
     }
 
     companion object {
         private const val PROP_LAST_ADDRESS = "opencode.lastAddress"
         private const val PROP_LAST_PASSWORD = "opencode.lastPassword"
+        private const val PROP_CUSTOM_BASE_PATH = "opencode.customBasePath"
         
         /**
          * Shows the dialog and returns the result.
@@ -159,7 +181,7 @@ class OpenCodeConnectDialog(
         fun show(project: Project, defaultPort: Int): ConnectionInfo? {
             val dialog = OpenCodeConnectDialog(project, defaultPort)
             return if (dialog.showAndGet()) {
-                ConnectionInfo(dialog.hostname, dialog.port, dialog.password, dialog.useWebInterface)
+                ConnectionInfo(dialog.hostname, dialog.port, dialog.password, dialog.useWebInterface, dialog.customBasePath)
             } else {
                 null
             }

--- a/src/main/kotlin/ai/opencode/ide/jetbrains/ui/OpenCodeConnectDialog.kt
+++ b/src/main/kotlin/ai/opencode/ide/jetbrains/ui/OpenCodeConnectDialog.kt
@@ -1,7 +1,10 @@
 package ai.opencode.ide.jetbrains.ui
 
 import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessModuleDir
+import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.components.JBLabel
@@ -34,7 +37,9 @@ class OpenCodeConnectDialog(
 
     private val addressField = JBTextField("127.0.0.1:$defaultPort")
     private val passwordField = JBPasswordField()
-    private val basePathField = JBTextField()
+    private val basePathField = ComboBox<String>().apply {
+        isEditable = true
+    }
     
     var hostname: String = "127.0.0.1"
         private set
@@ -80,7 +85,19 @@ class OpenCodeConnectDialog(
         }
 
         // Load saved custom base path
-        basePathField.text = props.getValue(PROP_CUSTOM_BASE_PATH, "")
+        val savedPath = props.getValue(PROP_CUSTOM_BASE_PATH, "")
+
+        // Populate module paths
+        val moduleManager = ModuleManager.getInstance(project)
+        val modules = moduleManager.modules
+        val paths = modules.mapNotNull { it.guessModuleDir()?.path }.sorted()
+        paths.forEach { basePathField.addItem(it) }
+
+        if (savedPath.isNotBlank()) {
+            basePathField.item = savedPath
+        } else {
+            basePathField.selectedIndex = -1
+        }
 
         addressField.toolTipText = "Format: hostname:port (e.g., 127.0.0.1:4096)"
         passwordField.toolTipText = "OPENCODE_SERVER_PASSWORD"
@@ -137,7 +154,7 @@ class OpenCodeConnectDialog(
         val passwordValue = passwordField.password.concatToString().trim()
         password = passwordValue.ifBlank { null }
         
-        val basePathValue = basePathField.text.trim()
+        val basePathValue = (basePathField.editor.item as? String)?.trim() ?: ""
         customBasePath = basePathValue.ifBlank { null }
 
         useWebInterface = false


### PR DESCRIPTION
# Summary
This PR introduces the ability for users to specify a custom base path (working directory) when connecting to or starting an OpenCode terminal session. This is particularly useful for projects with multiple modules or when the OpenCode CLI needs to be executed from a specific subdirectory.

<img width="403" height="399" alt="Screenshot from 2026-03-12 18-29-12" src="https://github.com/user-attachments/assets/071a9e7c-6eb4-4b98-a5b7-a7ff451a2536" />

# Changes

## UI Enhancements:
Updated OpenCodeConnectDialog to include a "Custom base path" dropdown.
The dropdown is automatically populated with paths to all modules in the current project for easy selection.
Added persistence for the custom base path using PropertiesComponent, so the last used path is remembered across sessions.
Increased the default dialog size to accommodate the new input field.

##Service Logic:
Modified OpenCodeService to propagate the customBasePath throughout the connection lifecycle.
Updated createTerminalUIInternal to use the specified custom path as the working directory for the terminal widget.
Ensured that if no custom path is provided, it defaults to the project's base path as before.

## Verification Results
Verified that the "Custom base path" field appears in the connection dialog.
Confirmed that module paths are correctly listed and selectable.
Validated that starting a session with a custom path correctly sets the terminal's working directory.
Confirmed that the chosen path is saved and restored when reopening the dialog.

## Note
This change is based on the proposal described in the issue #11. In addition to the original proposal, the implementation includes a dropdown that lists all detected project modules, making it easier to select an appropriate base path. This enhancement provides a more convenient and less error-prone way for users to choose the correct working directory when multiple modules are present in a project.