### PR TITLE
docs: add designDocs English translations and note to remove #6 from AGENTS.md for non-Chinese readers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ src/main/kotlin/ai/opencode/ide/jetbrains/
 - **Read/Write Actions**: Modifying the PSI or VFS requires a Write Action (`runWriteAction`). Reading requires a Read Action.
 - **SDK Compatibility**: Ensure APIs used are available in the target version (see `build.gradle.kts`).
 
-## 6. 语言规则
+## 6. 语言规则  [ Note: Instruction for models to responsd in Chinese - remove if you can't read Chinese! ]
 
 - **必须使用中文回复**: 所有对用户的回复、解释和沟通**必须**使用中文进行。
 

--- a/designDocs/en/base_feature.plan.md
+++ b/designDocs/en/base_feature.plan.md
@@ -1,0 +1,168 @@
+# base_feature.plan.md - OpenCode JetBrains Plugin
+
+**Author**: hhlai1990@gmail.com
+
+## Overview
+
+This is a JetBrains IDE plugin that integrates [OpenCode](https://opencode.ai) (an open-source AI coding agent) into the IDE workflow.
+
+This document describes the user experience and implementation details of the "base features," aligned with the interaction patterns of the Claude Code JetBrains plugin.
+
+## Implemented Features
+
+### 1) Quick Launch (Open/Focus Terminal)
+
+| Platform | Shortcut |
+|----------|----------|
+| Mac | `Cmd + Esc` |
+| Windows/Linux | `Ctrl + \` |
+
+**Behavior:**
+- Shows a connection dialog allowing the user to enter a custom `host:port` and optional password (default `127.0.0.1:4096`).
+  - **WSL Note**: If the OpenCode server runs in WSL, `127.0.0.1` is not directly reachable — user must enter the WSL actual IP.
+  - **IPv6 Note**: Avoid using `localhost`; some Windows environments resolve it to IPv6, causing connection failures. Recommend forcing `127.0.0.1`.
+- **Persistent Memory**: Auto-saves the last connected address and password (stored using simple Base64 encoding).
+- **Connect to Existing Server**: Detect and connect to OpenCode Desktop or another already-running OpenCode server. Supports automatic HTTP Basic Authentication, manual password entry, and passing credentials via environment variables to the CLI.
+  - **Process Info Reading Compatibility**: Windows may depend on PowerShell/WMI; Linux reading `/proc/{pid}/environ` may be restricted by permissions. On failure, must fall back to manual password entry.
+- **Create New Terminal**: If hostname is localhost and the port is the default, creates an `OpenCode({port})` terminal tab in the **Editor area** and starts the local server (more space, better for TUI display).
+- The IDE does NOT auto-create a terminal on startup; only explicit user action triggers launch.
+
+### 2) Add Context to Terminal
+
+| Platform | Shortcut |
+|----------|----------|
+| Mac | `Opt + Cmd + K` |
+| Windows/Linux | `Ctrl + Alt + K` |
+
+**Behavior:**
+- **Editor (with selection)**: Sends `@path#Lstart-end` (reference only, no source content sent).
+- **Editor (no selection)**: Sends `@path` (current file reference).
+- **Project View (multi-select files/directories)**: Sends `@path` for each entry.
+- **Path Format Convention**: `@path` uniformly uses project-relative paths with forward slashes `/`, avoiding Windows `\` parsing failures.
+- If the OpenCode terminal is not open: the plugin auto-creates/focuses the terminal, then inserts the reference (avoids the "no terminal, no response" confusion).
+
+### 3) Sidebar Icon (Right Toolbar)
+
+- Right toolbar displays a single OpenCode icon.
+- Clicking the icon triggers Quick Launch behavior (focus/create terminal).
+- The ToolWindow itself shows no complex content: it hides immediately after triggering (aligned with Claude's "click to jump" style).
+
+## Technical Implementation
+
+### Architecture (Core Objects)
+
+```
+OpenCodeService (Project-scoped)
+├── focusOrCreateTerminal()            # Shows connection dialog, connects or creates terminal
+├── connectToExistingServer()          # Connect to an existing OpenCode server (supports auto-auth)
+├── createTerminalAndConnect()         # Create terminal tab in Editor area and start server
+├── pasteToTerminal()                  # Paste to existing terminal
+└── focusOrCreateTerminalAndPaste()    # Unified UX: auto-creates and retries paste
+
+OpenCodeTerminalVirtualFile            # Virtual file representing a terminal tab in Editor
+OpenCodeTerminalFileEditor             # FileEditor implementation, wraps terminal widget
+OpenCodeTerminalFileEditorProvider     # FileEditorProvider, manages terminal editor creation
+
+OpenCodeConnectDialog                  # Connection dialog (input host:port + optional password)
+ProcessAuthDetector                    # Auto-detect OpenCode Desktop authentication info
+OpenCodeApiClient                      # HTTP API client (supports Basic Auth)
+SseEventListener                       # SSE event listener (supports Basic Auth)
+PortFinder                             # Port detection and health check (supports Basic Auth)
+
+OpenCodeToolWindowFactory              # Right toolbar icon behavior
+QuickLaunchAction                      # Cmd+Esc / Ctrl+\ handler
+SendSelectionToTerminalAction          # Opt+Cmd+K handler
+```
+
+### Session & API Client Listening Mechanism
+
+**Core Mechanism: Active Pull (Recovery) + Real-time Push (SSE)**
+
+Listeners are bound to the **project path**, not a single Session. This means any operations on the same project from the same Server are detectable by the IDE, which auto-switches focus.
+
+```mermaid
+sequenceDiagram
+    participant IDE as OpenCode Plugin
+    participant API as API Client
+    participant SSE as SSE Listener
+    participant Server as OpenCode Server
+
+    Note over IDE, Server: 1. Connection & Recovery (Pull)
+    IDE->>API: GET /session/status?directory={path}
+    alt Busy Session Exists
+        API-->>IDE: Returns Busy Session ID
+    else No Busy Session
+        IDE->>API: GET /session?directory={path}
+        API-->>IDE: Returns Session list (sorted by update time)
+        IDE->>IDE: Select latest Session as Active
+    end
+
+    Note over IDE, Server: 2. Real-time Listening (Push)
+    IDE->>SSE: Connect /event?directory={path}
+    loop SSE Event Stream
+        Server-->>SSE: Event (Status/Idle/FileEdited)
+        SSE-->>IDE: Dispatch Event
+        
+        alt Event: Session Status (Busy)
+            IDE->>IDE: Update Active Session ID
+            IDE->>IDE: Capture local file snapshot (Baseline Snapshot)
+        else Event: File Edited
+            IDE->>IDE: Refresh VFS (FileDocumentManager)
+        else Event: Session Idle (Complete)
+            IDE->>API: GET /session/{id}/diff
+            API-->>IDE: Return Diff data
+            IDE->>IDE: Show Diff Viewer interface
+        end
+    end
+```
+
+**Key Strategies:**
+
+1. **Project-Level Locking**: Listening is based on physical path, covering all concurrent Sessions under that path.
+2. **Active Preemption**: Any Session transitioning to `busy` status becomes the `activeSessionId`, ensuring the Diff Viewer always shows the currently-working AI context.
+3. **Baseline Snapshot**: Captures local file state at the `busy` moment as the "source of truth" for Reject operations, solving the problem of potentially inaccurate server-side `before` content.
+
+### Key APIs
+
+- `TerminalView.createLocalShellWidget()` - Create Terminal widget
+- `ShellTerminalWidget.executeCommand()` - Execute command
+- `TtyConnector.write()` - Inject text into terminal
+- `FileEditorManager` - Manage Editor area files/tabs
+- `FileEditorProvider` - Custom Editor types (for terminal tabs)
+- `FileEditorManagerListener` - Listen for Editor tab close events
+- `Alarm` - Debounce/scheduling (avoids custom thread pools)
+
+### plugin.xml (Key Registration Points)
+
+- Actions:
+  - `OpenCode.QuickLaunch` (Tools menu + shortcut)
+  - `OpenCode.AddLines` (EditorPopupMenu)
+  - `OpenCode.AddFile` (ProjectViewPopupMenu)
+- Extensions:
+  - `toolWindow` id=`OpenCode`
+  - `projectService`: `OpenCodeService` / `SessionManager` / `DiffViewerService`
+
+## Project Structure (Key Paths)
+
+```
+src/main/kotlin/ai/opencode/ide/jetbrains/
+├── OpenCodeService.kt
+├── OpenCodeToolWindow.kt
+├── QuickLaunchAction.kt
+├── SendSelectionToTerminalAction.kt
+├── diff/
+├── session/
+├── terminal/
+├── util/
+
+src/main/resources/META-INF/plugin.xml
+```
+
+## Test Cases
+
+1. Press `Cmd+Esc` / `Ctrl+\`: Create or focus `OpenCode({port})` terminal tab in Editor area.
+2. Editor no selection, press `Opt+Cmd+K`: Insert `@current-file`.
+3. Editor with selection, press `Opt+Cmd+K`: Insert `@current-file#Lx-y`.
+4. Project View multi-select files/directories, press `Opt+Cmd+K`: Insert multiple `@path`.
+5. Click OpenCode icon in right toolbar: Focus/create terminal in Editor area.
+6. Close OpenCode terminal tab: Auto-cleanup connection state.

--- a/designDocs/en/diff_feature_plan.md
+++ b/designDocs/en/diff_feature_plan.md
@@ -1,0 +1,364 @@
+# OpenCode JetBrains Diff Feature Design
+
+## Overview
+
+This document describes the diff workflow for the OpenCode JetBrains plugin. The design philosophy aligns with Claude Code: the Working Tree is the source of truth, explicit `file.edited` events and `DocumentListener` are used for change attribution, and LocalHistory is used for safe rollback.
+
+---
+
+## Core Architecture & Data Flow
+
+The plugin prioritizes **local Git operations** over server-side revert APIs. This keeps the plugin resilient in stateless mode and leverages JetBrains' VCS integration.
+
+### Diff Flow
+
+```mermaid
+sequenceDiagram
+    participant Server
+    participant SSE
+    participant OCS as OpenCodeService
+    participant SM as SessionManager
+    participant DL as DocumentListener
+    participant Disk
+    participant Diff as DiffViewer
+
+    Server->>SSE: session.status(busy)
+    SSE->>OCS: session.status
+    OCS->>SM: onTurnStart
+    SM->>SM: Clear userEditedFiles
+    SM->>SM: Create LocalHistory label
+    Note right of SM: Gap Event Capture: Retain vfsChangedFiles/serverEditedFiles
+
+    Note over DL, Disk: User typing in IDE
+    DL->>SM: Detect user edits
+    SM->>SM: Record to UserList
+
+    Note over Server, Disk: AI writes to disk
+    Server->>Disk: Write files
+    SSE->>OCS: file.edited event
+    OCS->>SM: Record to AI EditList
+
+    Server->>SSE: message.updated / command.executed
+    SSE->>OCS: Cache messageID
+    Server->>SSE: session.diff (optional)
+    SSE->>OCS: Cache diff payload
+
+    Server->>SSE: session.idle
+    SSE->>OCS: attemptBarrierTrigger
+    OCS->>OCS: Wait for Idle + ID/Payload
+    OCS->>Server: getSessionDiff(messageID)
+    OCS->>SM: getProcessedDiffs(serverDiffs, snapshot)
+    Note right of SM: Centralized Rescue, Resolution, Filtering
+    SM->>Disk: Read current content (merged)
+    SM->>Diff: Show diff chain (labeled OpenCode + User)
+
+    Diff->>SM: Accept
+    SM->>Disk: git add (stage merged state)
+
+    Diff->>SM: Reject
+    alt User Edited this file
+        SM->>Diff: Show data loss warning
+    end
+    SM->>Disk: Restore LocalHistory baseline
+```
+
+---
+
+## Key Workflows
+
+### 1. Diff Collection & Display
+
+- **Triggers**: SSE `session.status` (`busy` → `idle`) and `session.idle`.
+- **Strategy: Server Authoritative + Client-side Smart Correction**: 
+  - **Server Authoritative**: Default trust in server-returned Diff data.
+  - **Pre-Filter (Stale Protection)**: If the server Diff shows no change (`Before == After`) but VFS detected physical modification, treat server data as stale, forcefully discard the Diff and trigger Rescue.
+  - **Gap State Sync**: At `onTurnStart`, sync Gap-period (idle period) user modifications to in-memory snapshots, preventing AI from overwriting user modifications made between turns.
+  - **VFS Rescue**: For files missed or stale from the server (deleted, created, or modifications discarded by Pre-Filter), synthesize Diffs using local snapshots.
+
+- **Busy Start**:
+  - **Gap Sync**: Sync Gap-period `vfsChangedFiles` to `lastKnownFileStates`.
+  - **Memory Snapshot**: Lock current known state as `startOfTurnKnownState`.
+  - Create LocalHistory baseline label `OpenCode Modified Before`.
+
+- **Idle Phase**:
+  - **Strict Barrier**: Wait for Idle + ID/Payload.
+  - **Baseline Resolution (4-level fallback)**:
+    1. **Pre-emptive Capture (`capturedBeforeContent`)**: Highest priority. Content captured via VFS events before turn start.
+    2. **LocalHistory**: Trace back through the Turn Start Label.
+    3. **Known State**: In-memory snapshot (handles state loss after Reject).
+    4. **Disk Fallback**: Only read disk when Server intent is deletion (`After=""`) and `Before=""` (prevents new-file false positives).
+  - **Content Filtering**: Filter out `Before == After` files unless **VFS Rescue** triggers.
+
+- **Display**: Uses DiffManager multi-file chain display.
+
+### 2. Accept (Stage Changes)
+
+- **Operation**: `git add <file>` or `git add -A <file>`.
+- **Behavior**: Stages current disk content.
+
+### 3. Reject (Restore Changes)
+
+- **Operation**: Restore to `before` state (prefer LocalHistory, fallback to Server Before).
+- **Safety**:
+  - If file contains user edits, show warning dialog before proceeding.
+  - If determined to be a newly-created file, perform physical deletion.
+
+---
+
+## Strategy Matrix
+
+| Scenario | File State | OpenCode Action | User Action | Diff Label | Reject Behavior |
+|----------|------------|-----------------|-------------|------------|-----------------|
+| **A** | Modified | Edited | None | Normal | Restore baseline |
+| **B** | Modified | Edited | Edited | Modified (OpenCode + User) | **Warn** -> Restore |
+| **C** | Diff Only | (VFS delayed) | None | Normal | Restore Server Before |
+| **D** | New File | Created | Edited | Modified (OpenCode + User) | **Warn** -> Delete |
+
+---
+
+## Known Issues & Mitigations
+
+- **Missing `messageID`**: Triggers Barrier Timeout (2 seconds), uses session summary or SSE payload as fallback.
+- **Server Chinese Filename Encoding**: Handled by `FileDiffDeserializer`.
+- **LocalHistory Lookup Failure**: Fallback order is Known State (memory) → Disk Fallback (delete intent only) → Server Before.
+- **Ghost Diff**: Uses `Before == After` filter, VFS Rescue prevents filtering genuine deletions.
+- **Late Baseline Race Condition**: Resolved via Gap Event Capture (VFS event rotation at Turn End).
+
+---
+
+## Implementation Details (2026-01-24 Architecture Final)
+
+### Core Architecture: Signal Separation & Pre-emptive Capture
+
+We built a layered defense system to fundamentally solve timing races and signal confusion.
+
+#### 1. Signal Separation & Conservative Rescue
+
+SessionManager strictly distinguishes these signals:
+* **VFS Changes (`vfsChangedFiles`)**: Physical file changes.
+* **Server Claims (`serverEditedFiles`)**: Files the AI explicitly declared it modified (via SSE `file.edited` events).
+* **User Edits (`userEditedFiles`)**: Manual user input detected by the IDE.
+
+**Pre-Filter (Smart Pre-Filtering)**:
+Before processing Server Diffs, check `if (diff.before == diff.after && isVfsTouched)`. If true, the Server returned stale data — directly discard and force Rescue to read latest disk state.
+
+**Conservative Rescue Strategy** (2026-01-25 Fix):
+
+To prevent false positives (e.g., user actions misattributed to AI), Rescue requires strict AI affinity conditions:
+
+**Common Prerequisites**:
+* Server API Diff list does NOT contain this file (or it was discarded by Pre-Filter)
+* File is NOT in `userEditedFiles` list (excludes user actions)
+
+**Deleted File Rescue** (`!exists`):
+1. Has `capturedBeforeContent` (we know the original content, can safely restore)
+2. Or Server declared this file via `file.edited` SSE (`serverEditedFiles`)
+
+**New File Rescue** (`exists && isVfsCreated`):
+* **Must satisfy both** VFS detection of creation (`aiCreatedFiles`) + Server SSE declaration (`serverEditedFiles`)
+
+**Modified File Rescue** (`exists && !isVfsCreated`):
+* **Must satisfy** Server SSE declaration (`serverEditedFiles`). Used to fix modification loss caused by server Diff lag.
+
+This strategy effectively resolves:
+* Ghost Diffs (Diffs with no substantive changes)
+* Diff loss during continuous file modifications (via Pre-Filter + Rescue)
+* User manual edits being claimed by AI
+
+#### 3. Filtering Strategy
+
+To balance Diff visibility and safety, we use a "Server Authoritative with Affinity Check" strategy.
+
+* **Core Principles**:
+  * **API Trust**: Prioritize Server API returned Diffs.
+  * **Affinity Check**: To prevent the Server from returning stale Diffs from previous turns, require each file to have "signs of life" in the current Turn.
+  * **Valid Signals**: SSE claims (`serverEditedFiles`) **or** VFS physical changes (`vfsChangedFiles`/`captured`/`aiCreated`).
+  * **Rule**: `if (!isServerClaimed && !isVfsTouched) -> SKIP`.
+
+* **Hard Filters**:
+  1. **User Conflict (User Safety)**:
+     * `if (isUserEdited) -> SKIP`: If the user manually edited this file during the current Turn, **absolutely do not show**. This is the highest-priority rule.
+  2. **No Substantive Change (Ghost Diffs)**:
+     * `if (Before == After) -> SKIP`: If the resolved "before" content is identical to the current disk content, treat as invalid Diff, do not display.
+
+* **Turn Isolation (Strict Isolation)**:
+  * Force-clear all change collections at `onTurnStart`, ensuring stale signals from previous turns never pollute the current one. This makes affinity checks precise.
+
+---
+
+## Core Architecture Refactor (Old Archive)
+
+The refactored architecture follows the "Server Authoritative" principle:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                       OpenCodeService                            │
+│  (SSE event dispatch, Turn lifecycle triggers, API calls,        │
+│   Barrier coordination)                                          │
+├─────────────────────────────────────────────────────────────────┤
+│  handleEvent()                                                   │
+│    ├─ session.status(busy)  → sessionManager.onTurnStart()       │
+│    │                          clearTurnState()                   │
+│    ├─ file.edited           → sessionManager.onFileEdited()      │
+│    ├─ session.status(idle)  → sessionManager.onTurnEnd()         │
+│    │   session.idle           + turnSnapshots[sId] = snapshot    │
+│    │                          attemptBarrierTrigger()            │
+│    ├─ message.updated       → recordTurnMessageId()              │
+│    └─ session.diff          → turnPendingPayloads[sId] = diffs   │
+│                                                                  │
+│  Barrier Logic:                                                  │
+│    - Wait for (Idle + MessageID) or (Idle + Payload)             │
+│    - Timeout: 2000ms → force fetch                               │
+│    - Debounce: 1500ms between triggers                           │
+└─────────────────────────────────────────────────────────────────┘
+                                 │
+                                 ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                       SessionManager                             │
+│  (Turn state, Diff processing, Baseline resolution,              │
+│   Accept/Reject operations)                                      │
+├─────────────────────────────────────────────────────────────────┤
+│  Turn State:                                                     │
+│    - turnNumber: Int (monotonic increasing isolation)            │
+│    - isBusy: Boolean                                             │
+│    - baselineLabel: Label (LocalHistory baseline)                │
+│    - aiEditedFiles: ConcurrentSet (VFS detection, Gap Event      │
+│      Capture)                                                    │
+│    - aiCreatedFiles: ConcurrentSet (new file detection)          │
+│    - userEditedFiles: ConcurrentSet (conflict detection)         │
+│    - lastKnownFileStates: Map (in-memory snapshot after Reject)  │
+│                                                                  │
+│  Core APIs:                                                      │
+│    - onTurnStart(): Boolean (begin new Turn)                     │
+│    - onTurnEnd(): TurnSnapshot? (create immutable snapshot)      │
+│    - processDiffs(serverDiffs, snapshot): List<DiffEntry>        │
+│    - resolveBeforeContent(path, diff, snapshot): String          │
+│    - acceptDiff(entry, callback): async git add                  │
+│    - rejectDiff(entry, callback): async file restore             │
+└─────────────────────────────────────────────────────────────────┘
+                                 │
+                                 ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                       DiffViewerService                          │
+│  (Multi-file Diff display, navigation)                           │
+├─────────────────────────────────────────────────────────────────┤
+│  showMultiFileDiff(entries, startIndex)                          │
+│    → Create DiffChain                                            │
+│    → Register Accept/Reject Actions                              │
+│    → Open IDE Diff Window                                        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Simplified Data Model
+
+**DiffEntry** (current implementation):
+
+```kotlin
+data class DiffEntry(
+    val file: String,                    // Relative path (normalized)
+    val diff: FileDiff,                  // File diff content
+    val hasUserEdits: Boolean = false,   // Whether user also edited
+    val resolvedBefore: String? = null,  // Resolved Before content (from LocalHistory or memory snapshot)
+    val isCreatedExplicitly: Boolean = false  // Whether VFS detected creation event
+) {
+    /** 
+     * Determine if this is a newly-created file. Must satisfy both:
+     * 1. VFS detected creation event (physical creation)
+     * 2. Server Diff shows no prior content (logical creation)
+     * This prevents "Replace" operations (Delete+Create) from being
+     * misidentified as new files.
+     */
+    val isNewFile: Boolean get() = isCreatedExplicitly && diff.before.isEmpty()
+    
+    /** Get Before content: prefer resolved value, fallback to Server value */
+    val beforeContent: String get() = resolvedBefore ?: diff.before
+}
+```
+
+**Removed Redundant Fields**:
+- `DiffBatch`, `DiffBatchSummary` (unused)
+- `sessionId`, `messageId`, `partId`, `timestamp` (unused)
+- `canRevert()` method (logic inlined into reject flow)
+
+### Accept/Reject Async Operation Design
+
+`acceptDiff` and `rejectDiff` use a **callback pattern**:
+
+```kotlin
+fun acceptDiff(entry: DiffEntry, onComplete: ((Boolean) -> Unit)? = null)
+fun rejectDiff(entry: DiffEntry, onComplete: ((Boolean) -> Unit)? = null)
+```
+
+**Key Design Decisions**:
+
+1. **Deferred State Cleanup**: `pendingDiffs.remove(path)` only executes after successful operation.
+2. **Callbacks Invoked on EDT**: Callers can safely update UI.
+3. **Edge Case Handling**:
+   - `acceptDiff`: Double-verify with `waitFor` return value and `exitCode`.
+   - `rejectDiff`: File not found and before is empty → treat as success (no-op scenario).
+
+### Reject User Edit Warning
+
+Per the strategy matrix, when `entry.hasUserEdits == true` (scenarios B/D), show a data loss warning:
+
+```
+WARNING: You have also edited this file. Your changes will be lost!
+```
+
+Dialog title changes to "Confirm Reject (Data Loss Warning)" to emphasize risk.
+
+### Turn Lifecycle & Snapshot Mechanism
+
+```kotlin
+// 1. Turn Start (session.status → busy)
+sessionManager.onTurnStart(): Boolean
+  → turnNumber++
+  → isBusy = true
+  → Clear userEditedFiles
+  → Create LocalHistory baseline label
+  → NOTE: aiEditedFiles/aiCreatedFiles NOT cleared here (Gap Event Capture)
+
+// 2. Edit Tracking
+sessionManager.onFileEdited(path)  // AI edit (from file.edited SSE)
+VFS Listener                        // Auto-detect filesystem changes
+documentListener                    // User edits (auto-detected in IDE)
+
+// 3. Turn End (session.idle)
+sessionManager.onTurnEnd(): TurnSnapshot?
+  → isBusy = false
+  → Create TurnSnapshot (immutable snapshot)
+  → Rotate aiEditedFiles/aiCreatedFiles to new collections (Gap Event Capture)
+  → Return Snapshot for subsequent processing
+
+// 4. Diff Display (triggered by OpenCodeService)
+fetchAndShowDiffs(sessionId, snapshot)
+  → GET /session/:id/diff?messageID=xxx
+  → forceVfsRefresh(diffs + knownFiles) // Ensure physical deletions are detected
+  → sessionManager.getProcessedDiffs(serverDiffs, snapshot, lateVfsEvents)
+      → VFS Rescue (Synthetic Diffs)
+      → Resolve Before Content
+      → Filtering (Signal Affinity, User Safety, Content)
+  → diffViewerService.showMultiFileDiff(entries)
+```
+
+**TurnSnapshot** (immutable state snapshot):
+
+```kotlin
+data class TurnSnapshot(
+    val turnNumber: Int,
+    val aiEditedFiles: Set<String>,      // AI edits detected by VFS
+    val aiCreatedFiles: Set<String>,     // New files detected by VFS
+    val userEditedFiles: Set<String>,    // User edits detected by IDE
+    val baselineLabel: Label?,           // LocalHistory baseline
+    val knownFileStates: Map<String, String> // Known state after Reject
+)
+```
+
+---
+
+## Future Roadmap
+
+### 1. Fine-Grained (Hunk-Level) Attribution
+- **Current**: Attribution is file-level.
+- **Goal**: Use side-by-side or three-way diff to distinguish which lines were modified by AI vs. user.
+- **Requirements**: Reliable server-side `after` content or internal offset tracking.

--- a/designDocs/en/opencode_api_notes.md
+++ b/designDocs/en/opencode_api_notes.md
@@ -1,0 +1,108 @@
+## OpenCode Server API Study Notes
+
+> Sources:
+> - Official documentation: https://opencode.ai/docs/server/
+> - JS SDK: `sdk/js/src/gen/types.gen.ts`, `sdk/js/src/gen/sdk.gen.ts`
+
+---
+
+## Overview
+
+- Server provides OpenAPI 3.1 (`/doc`), with a generated JS SDK.
+- SSE events are subscribable via `/event?directory=`, or `/global/event` for global events.
+- Session-related APIs are under `/session`, with `messageID` being the key link between diffs and session operations.
+
+---
+
+## Sessions API (Core)
+
+### Session List & Status
+
+- `GET /session?directory=`
+  - Returns `Session[]`, includes `time.updated` for finding the latest session.
+- `GET /session/status?directory=`
+  - Returns `{ [sessionID]: SessionStatus }`, for identifying Busy/Idle.
+- `GET /session/:id?directory=`
+  - Get single session details.
+
+### Diff
+
+- `GET /session/:id/diff?directory=&messageID?`
+  - `messageID` is **optional but important**, used to locate the diff produced by a specific message.
+  - Without `messageID`, may return historical diffs for that session (causing false positives).
+
+### Other Key Session Operations
+
+- `POST /session`: Create session
+- `PATCH /session/:id`: Update title
+- `DELETE /session/:id`: Delete session
+- `POST /session/:id/abort`: Abort session
+- `POST /session/:id/revert`, `POST /session/:id/unrevert`
+- `POST /session/:id/permissions/:permissionID`
+
+---
+
+## Messages / Commands API (messageID Association)
+
+- `POST /session/:id/command`
+  - Execute commands like `/mystatus`, returns Message (with `id`).
+- `GET /session/:id/message?limit?`
+  - Returns `{ info: Message, parts: Part[] }[]`
+- `POST /session/:id/message`
+  - Returns `{ info: Message, parts: Part[] }`
+
+**Message Structure Key Points (SDK)**
+- `Message.id` = `messageID`
+- `Message.sessionID` links to session
+- `Message.role` = `user` or `assistant`
+
+---
+
+## SSE Events (SDK Reference)
+
+### Event Subscription
+
+- `/event?directory=` (corresponds to SDK `EventSubscribeData`)
+- `/global/event` (SDK Global event)
+
+### Events of Interest for This Plugin
+
+- `session.status` → `{ sessionID, status }`
+- `session.idle` → `{ sessionID }`
+- `session.diff` → `{ sessionID, diff: FileDiff[] }`
+- `file.edited` → `{ file }`
+- `message.updated` → `{ info: Message }` (Message contains `id`, `sessionID`, `role`)
+- `command.executed` → `{ name, sessionID, arguments, messageID }`
+
+**SDK Definition Reference**
+- `EventMessageUpdated.properties.info` (not `messageID`)
+- `EventCommandExecuted.properties.name/arguments/messageID` (not a `command` field)
+
+---
+
+## Key Conclusions / Usage Recommendations
+
+1. **Always include `messageID` when fetching diffs**
+   - Without it, historical diffs may be returned (deleted files can appear as "new changes").
+2. **`message.updated` events must parse `info.id` as messageID**
+   - The SDK clearly places this field in `info`, not directly in `properties`.
+3. **`command.executed` events provide a reliable messageID**
+   - Especially important for `/mystatus` and similar command scenarios.
+4. **`message.part.updated` can serve as a fallback source**
+   - Part objects contain `sessionID` and `messageID`, useful when `message.updated` is missing.
+5. **Idempotently clean state when session enters `busy`**
+   - Only clear `turnMessageIds` etc. when `status.isBusy() && changed` is true, preventing re-sent busy signals from wiping mid-arrival `file.edited` events.
+6. **Fetch Priority Strategy**
+   - 1. `messageID`-linked API result (most accurate); 2. SSE-pushed `session.diff` (fallback); 3. `Session Summary` (last resort).
+
+---
+
+## Plugin's Current API Usage Points (Reviewed)
+
+- `/event?directory=`: SSE event subscription
+- `/global/health`: Health check
+- `/session/status`: Find busy session
+- `/session`: Get latest session
+- `/session/:id`: Get session summary (diff fallback)
+- `/session/:id/diff?messageID?`: Display diff
+- `/tui/append-prompt`: Append command to TUI

--- a/designDocs/en/testing_strategy.md
+++ b/designDocs/en/testing_strategy.md
@@ -1,0 +1,139 @@
+# OpenCode Plugin Testing Strategy
+
+This document comprehensively describes the OpenCode JetBrains plugin's testing strategy, including the automated test architecture, core business logic analysis, and manual regression test cases.
+
+---
+
+## Part 1: Automated Testing
+
+We use a three-layer test architecture to ensure functional correctness and stability, especially focused on Diff feature Turn isolation and race conditions.
+
+### Test Architecture
+
+```
+Layer 3: Real IDE + Real OpenCode Server (RealProcessIntegrationTest)
+Layer 1: Mock IDE + Fake Server (OpenCodeLogicTest)
+```
+
+### 1. Logic Unit Tests (`OpenCodeLogicTest`)
+
+**Location**: `src/test/kotlin/ai/opencode/ide/jetbrains/integration/OpenCodeLogicTest.kt`
+
+**Purpose**: Verify core business logic in a controlled environment, especially complex concurrency and state management scenarios.
+
+**Key Components**:
+- **Mock IDE**: Uses Java Proxy to mock `Project` and IntelliJ platform components.
+- **Fake Server**: A lightweight Java HTTP Server simulating the OpenCode backend API and SSE event stream.
+
+**Covered Scenarios (Turn Scenarios)**:
+
+| Scenario | Description | Logic Verified |
+| :--- | :--- | :--- |
+| **Scenario A: Normal Turn** | Standard Busy -> File Edited -> Idle flow | Verify basic modification Diffs display correctly. |
+| **Scenario C: Turn Isolation** | Turn 1 ends, Turn 2 starts immediately | Verify Turn 1 Diffs do NOT pollute Turn 2 (Gap Event Filtering). |
+| **Scenario F: New File Safety** | AI creates a new file | Verify new file's Before is correctly resolved as empty, not reading new content from disk which would hide the Diff. |
+| **Scenario G: User Edit Safety** | User modifies file + VFS Change | Verify that if a user modifies a file while AI is working, the AI Diff for that file is strictly filtered (User Priority). |
+| **Scenario L: Rescue Deletion** | Server omission + physical deletion | Verify when a file physically disappears and the Server omits it, the system auto-remedies using captured original content (Captured/KnownState) and displays the Diff. |
+| **Scenario N: Server Authoritative** | No VFS signal + Server Diff | Verify that as long as there is an SSE declaration, even if VFS doesn't capture it (e.g., remote modification), the Server Diff displays. |
+| **Scenario O: Create then Modify** | Consecutive turns: create then modify | Verify Pre-Filter and Rescue mechanisms correctly handle server returning stale data (prevent filtering genuine modifications due to Before==After). |
+
+### 2. Real Integration Tests (`RealProcessIntegrationTest`)
+
+**Location**: `src/test/kotlin/ai/opencode/ide/jetbrains/integration/RealProcessIntegrationTest.kt`
+
+**Purpose**: Verify plugin code compatibility with a **real OpenCode binary**.
+
+**Verification Points**:
+- **Connection**: Auto-detect and launch `opencode serve`, establish real SSE/HTTP connections.
+- **Accept**: Simulate clicking "Accept" after AI modifies a file, verify the file is correctly `git add`-ed to staging.
+- **Reject**: Simulate clicking "Reject" after AI modifies a file, verify the file content is correctly restored.
+- **File Operations**: Cover edge cases like Delete, Create, Modify Empty File.
+
+### 3. How to Run Tests
+
+```bash
+# Run all tests
+./gradlew test
+
+# Run specific test
+./gradlew test --tests "ai.opencode.ide.jetbrains.integration.OpenCodeLogicTest"
+```
+
+---
+
+## Part 2: Turn Scenario Analysis
+
+This section details the internal logic flow of Turn isolation.
+
+### Core Data Flow (2026-01-24 Update)
+
+```mermaid
+sequenceDiagram
+    participant SSE
+    participant SessionManager
+    participant Snapshot
+    participant DiffViewer
+
+    SSE->>SessionManager: session.status(busy)
+    SessionManager->>SessionManager: onTurnStart()
+    
+    par Signal Separation
+        SessionManager->>SessionManager: Capture VFS Changes -> vfsChangedFiles
+        SSE->>SessionManager: file.edited -> serverEditedFiles
+    and Pre-emptive Capture
+        SessionManager->>SessionManager: beforeContentsChange -> capturedBeforeContent
+    end
+    
+    SSE->>SessionManager: session.status(idle)
+    SessionManager->>Snapshot: onTurnEnd() -> Create TurnSnapshot
+    Note right of Snapshot: Holds vfsChangedFiles, serverEditedFiles, capturedBeforeContent
+    
+    SessionManager->>DiffViewer: processDiffs(Snapshot)
+    DiffViewer->>DiffViewer: Resolve Before using Captured Content
+```
+
+### Key Mechanisms
+
+1. **TurnSnapshot**: Creates an immutable snapshot at Turn end. Subsequent Diff fetching and processing depends entirely on this snapshot.
+2. **Signal Separation**: Strictly distinguishes VFS physical changes from Server logical declarations, only rescuing intersections to prevent misattributing user actions.
+3. **Pre-emptive Capture**: Pre-emptively captures pre-change content using VFS events, solving timing race conditions.
+4. **Safe Rescue**: Applies strict Ghost Diff defense to rescue logic (prevents fabricating modifications out of thin air).
+
+---
+
+## Part 3: Manual Test Cases
+
+### Environment Setup
+1. Run plugin: `./gradlew runIde`
+2. Start OpenCode CLI.
+
+### TC-01: Basic Diff Display
+**Steps**: Have AI modify a file.
+**Expected**: Diff window pops up, showing changes.
+
+### TC-02: Delete File
+**Steps**: Have AI delete a file.
+**Expected**: Diff window pops up, showing file deletion. Clicking Reject should restore the file.
+
+### TC-03: New File
+**Steps**: Have AI create a new file.
+**Expected**: Diff window pops up. Clicking Reject should physically delete the file.
+
+### TC-04: Modify Empty File
+**Steps**: Create an empty file `empty.txt`, have AI modify it.
+**Expected**: Diff window pops up. Clicking Reject should clear the file content (does NOT delete the file).
+
+### TC-05: Replace File
+**Steps**: Have AI delete a file and create a new one with the same name.
+**Expected**: Reject should restore the old file content.
+
+### TC-06: Rapid Consecutive Conversations
+**Steps**: Send a message to modify file A, immediately send another message to modify file B before the Diff pops up.
+**Expected**: Ultimately should display Diffs for both A and B (or merged display), with no loss.
+
+---
+
+## Maintenance Guide
+
+- **Modifying SessionManager**: Must run `OpenCodeLogicTest`.
+- **Upgrading OpenCode**: Must run `RealProcessIntegrationTest`.


### PR DESCRIPTION
# Changes

## Design Docs Translations
Created `designDocs/en/` with English translations of all existing Chinese design documents:

- **base_feature.plan.md** — Plugin architecture, Quick Launch, terminal integration, and project structure
- **diff_feature_plan.md** — Diff workflow, signal separation, accept/reject logic, and data model
- **opencode_api_notes.md** — Server API study notes: sessions, diffs, SSE events
- **testing_strategy.md** — Test architecture, turn scenarios, and manual test cases

The original Chinese files remain untouched.

## AGENTS.md Cleanup
Added a self-documenting note to section 6 (语言规则 / Language Rules) for non-Chinese readers to remove this section which will cause their LLM model to respond in Chinese.

Intent was to allow for easier understanding for contributors who can not read Chinese while maintaining existing preference.