### PR TITLE
fix: add null safety to FileDiff getBefore/getAfter

### DIFF
--- a/src/main/kotlin/ai/opencode/ide/jetbrains/api/SseEventListener.kt
+++ b/src/main/kotlin/ai/opencode/ide/jetbrains/api/SseEventListener.kt
@@ -48,6 +48,7 @@ class SseEventListener(
 
     private val gson = GsonBuilder()
         .registerTypeAdapter(OpenCodeEvent::class.java, OpenCodeEventDeserializer())
+        .registerTypeAdapter(FileDiff::class.java, FileDiffDeserializer())
         .create()
 
     private var call: Call? = null

--- a/src/main/kotlin/ai/opencode/ide/jetbrains/session/SessionManager.kt
+++ b/src/main/kotlin/ai/opencode/ide/jetbrains/session/SessionManager.kt
@@ -690,7 +690,7 @@ open class SessionManager(private val project: Project) : Disposable {
      */
     fun resolveBeforeContent(relativePath: String, diff: FileDiff, snapshot: TurnSnapshot): String {
         val absPath = PathUtil.resolveProjectPath(project, relativePath)
-        val serverBefore = diff.before
+        val serverBefore = diff.before ?: ""
 
         // 1. VFS Creation Safety: If we detected a physical creation event, force before to empty.
         // This takes precedence because we KNOW it's a new file from our perspective.


### PR DESCRIPTION
Root cause: SseEventListener's Gson instance does not register FileDiffDeserializer, so when the server sends SSE diff events with null 'before'/'after' values, Gson creates FileDiff instances with null fields (bypassing constructor via UnsafeAllocator).

Fix:
1. Register FileDiffDeserializer in SseEventListener's Gson builder (prevents null fields at the source)
2. Add null-safe elvis operator in SessionManager.resolveBeforeContent (defense in depth)